### PR TITLE
Make name of MethodParameter optional in XML

### DIFF
--- a/etc/classfile.dtd
+++ b/etc/classfile.dtd
@@ -604,7 +604,7 @@
 
 <!ELEMENT method-parameters-attribute (method-parameter*) >
 
-<!ELEMENT method-parameter (name, final?, synthetic?, mandated?) >
+<!ELEMENT method-parameter (name?, final?, synthetic?, mandated?) >
 <!ATTLIST method-parameter
           access-flags CDATA #REQUIRED
 >

--- a/integration-tests/src/test/java/com/jeantessier/classreader/TestXMLPrinter.java
+++ b/integration-tests/src/test/java/com/jeantessier/classreader/TestXMLPrinter.java
@@ -1833,7 +1833,7 @@ public class TestXMLPrinter extends MockObjectTestCase {
         assertXPathCount(xmlDocument, "method-parameters-attribute", 1);
     }
 
-    public void testVisitMethodParameter() throws Exception {
+    public void testVisitMethodParameter_withAllSubElements() throws Exception {
         final MethodParameter methodParameter = mock(MethodParameter.class);
         final int accessFlags = 123;
         final String expectedAccessFlags = "00000000 01111011"; // 123 in binary
@@ -1841,16 +1841,16 @@ public class TestXMLPrinter extends MockObjectTestCase {
 
         checking(new Expectations() {{
             oneOf (methodParameter).getRawName();
-                will(returnValue(mockUtf8_info));
+            will(returnValue(mockUtf8_info));
             oneOf (mockUtf8_info).accept(printer);
             oneOf (methodParameter).getAccessFlags();
-                will(returnValue(accessFlags));
+            will(returnValue(accessFlags));
             oneOf (methodParameter).isFinal();
-                will(returnValue(true));
+            will(returnValue(true));
             oneOf (methodParameter).isSynthetic();
-                will(returnValue(true));
+            will(returnValue(true));
             oneOf (methodParameter).isMandated();
-                will(returnValue(true));
+            will(returnValue(true));
         }});
 
         printer.visitMethodParameter(methodParameter);
@@ -1863,6 +1863,36 @@ public class TestXMLPrinter extends MockObjectTestCase {
         assertXPathCount(xmlDocument, "method-parameter/final", 1);
         assertXPathCount(xmlDocument, "method-parameter/synthetic", 1);
         assertXPathCount(xmlDocument, "method-parameter/mandated", 1);
+    }
+
+    public void testVisitMethodParameter_noSubElements() throws Exception {
+        final MethodParameter methodParameter = mock(MethodParameter.class);
+        final int accessFlags = 0;
+        final String expectedAccessFlags = "00000000 00000000";
+
+        checking(new Expectations() {{
+            oneOf (methodParameter).getRawName();
+                will(returnValue(null));
+            oneOf (methodParameter).getAccessFlags();
+                will(returnValue(accessFlags));
+            oneOf (methodParameter).isFinal();
+                will(returnValue(false));
+            oneOf (methodParameter).isSynthetic();
+                will(returnValue(false));
+            oneOf (methodParameter).isMandated();
+                will(returnValue(false));
+        }});
+
+        printer.visitMethodParameter(methodParameter);
+
+        String xmlDocument = buffer.toString();
+        assertXPathCount(xmlDocument, "method-parameter", 1);
+        assertXPathCount(xmlDocument, "method-parameter/@access-flags", 1);
+        assertXPathText(xmlDocument, "method-parameter/@access-flags", expectedAccessFlags);
+        assertXPathCount(xmlDocument, "method-parameter/name", 0);
+        assertXPathCount(xmlDocument, "method-parameter/final", 0);
+        assertXPathCount(xmlDocument, "method-parameter/synthetic", 0);
+        assertXPathCount(xmlDocument, "method-parameter/mandated", 0);
     }
 
     public void testVisitModule_attributeWithVersion() throws Exception {

--- a/lib/src/main/java/com/jeantessier/classreader/XMLPrinter.java
+++ b/lib/src/main/java/com/jeantessier/classreader/XMLPrinter.java
@@ -1196,10 +1196,13 @@ public class XMLPrinter extends Printer {
         indent().append("<method-parameter access-flags=\"").append(format.format(helper.getAccessFlags())).append("\">").eol();
         raiseIndent();
 
-        indent();
-        append("<name>");
-        helper.getRawName().accept(this);
-        append("</name>").eol();
+        Optional.ofNullable(helper.getRawName())
+                .ifPresent(rawName -> {
+                    indent();
+                    append("<name>");
+                    rawName.accept(this);
+                    append("</name>").eol();
+                });
 
         if (helper.isFinal())     indent().append("<final/>").eol();
         if (helper.isSynthetic()) indent().append("<synthetic/>").eol();


### PR DESCRIPTION
Uses `Optional` to call `getRawName()` only once and handle the case when it returns `null`.  I could have used an `if` statement, but I'm exploring usage of `Optional`.

Fixes #9.