### PR TITLE
Fix windows launch scripts

### DIFF
--- a/bin/DependencyFinder.bat
+++ b/bin/DependencyFinder.bat
@@ -65,11 +65,16 @@ goto setupArgs
 rem This label provides a place for the argument list loop to break out
 rem and for NT handling to skip to.
 
+set DEPENDENCYFINDER_CLASSPATH=
+
+SETLOCAL ENABLEDELAYEDEXPANSION
+for %%j in (%DEPENDENCYFINDER_HOME%\lib\*.jar) do set DEPENDENCYFINDER_CLASSPATH=!DEPENDENCYFINDER_CLASSPATH!;%%j
+
 if "%DEPENDENCYFINDER_CONSOLE%"=="" goto noConsole
-"%JAVA_HOME%\bin\java" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_HOME%\lib\DependencyFinder.jar;%DEPENDENCYFINDER_HOME%\lib\jakarta-oro.jar;%DEPENDENCYFINDER_HOME%\lib\log4j.jar" com.jeantessier.dependencyfinder.gui.DependencyFinder %DEPENDENCYFINDER_CMD_LINE_ARGS%
+"%JAVA_HOME%\bin\java" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_CLASSPATH%" com.jeantessier.dependencyfinder.gui.DependencyFinder %DEPENDENCYFINDER_CMD_LINE_ARGS%
 goto doneRun
 :noConsole
-start "Dependency Finder" "%JAVA_HOME%\bin\javaw" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_HOME%\lib\DependencyFinder.jar;%DEPENDENCYFINDER_HOME%\lib\jakarta-oro.jar;%DEPENDENCYFINDER_HOME%\lib\log4j.jar" com.jeantessier.dependencyfinder.gui.DependencyFinder %DEPENDENCYFINDER_CMD_LINE_ARGS%
+start "Dependency Finder" "%JAVA_HOME%\bin\javaw" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_CLASSPATH%" com.jeantessier.dependencyfinder.gui.DependencyFinder %DEPENDENCYFINDER_CMD_LINE_ARGS%
 :doneRun
 
 if not "%OS%"=="Windows_NT" goto mainEnd

--- a/bin/OOMetrics.bat
+++ b/bin/OOMetrics.bat
@@ -65,7 +65,12 @@ goto setupArgs
 rem This label provides a place for the argument list loop to break out
 rem and for NT handling to skip to.
 
-"%JAVA_HOME%\bin\java" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_HOME%\lib\DependencyFinder.jar;%DEPENDENCYFINDER_HOME%\lib\jakarta-oro.jar;%DEPENDENCYFINDER_HOME%\lib\log4j.jar" com.jeantessier.dependencyfinder.cli.OOMetrics -default-configuration "%DEPENDENCYFINDER_HOME%\etc\MetricsConfig.xml" %DEPENDENCYFINDER_CMD_LINE_ARGS%
+set DEPENDENCYFINDER_CLASSPATH=
+
+SETLOCAL ENABLEDELAYEDEXPANSION
+for %%j in (%DEPENDENCYFINDER_HOME%\lib\*.jar) do set DEPENDENCYFINDER_CLASSPATH=!DEPENDENCYFINDER_CLASSPATH!;%%j
+
+"%JAVA_HOME%\bin\java" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_CLASSPATH%" com.jeantessier.dependencyfinder.cli.OOMetrics -default-configuration "%DEPENDENCYFINDER_HOME%\etc\MetricsConfig.xml" %DEPENDENCYFINDER_CMD_LINE_ARGS%
 
 if not "%OS%"=="Windows_NT" goto mainEnd
 :winNTend

--- a/bin/OOMetricsGUI.bat
+++ b/bin/OOMetricsGUI.bat
@@ -65,11 +65,16 @@ goto setupArgs
 rem This label provides a place for the argument list loop to break out
 rem and for NT handling to skip to.
 
+set DEPENDENCYFINDER_CLASSPATH=
+
+SETLOCAL ENABLEDELAYEDEXPANSION
+for %%j in (%DEPENDENCYFINDER_HOME%\lib\*.jar) do set DEPENDENCYFINDER_CLASSPATH=!DEPENDENCYFINDER_CLASSPATH!;%%j
+
 if "%DEPENDENCYFINDER_CONSOLE%"=="" goto noConsole
-"%JAVA_HOME%\bin\java" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_HOME%\lib\DependencyFinder.jar;%DEPENDENCYFINDER_HOME%\lib\jakarta-oro.jar;%DEPENDENCYFINDER_HOME%\lib\log4j.jar" com.jeantessier.dependencyfinder.gui.OOMetrics -default-configuration "%DEPENDENCYFINDER_HOME%\etc\MetricsConfig.xml" %DEPENDENCYFINDER_CMD_LINE_ARGS%
+"%JAVA_HOME%\bin\java" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_CLASSPATH%" com.jeantessier.dependencyfinder.gui.OOMetrics -default-configuration "%DEPENDENCYFINDER_HOME%\etc\MetricsConfig.xml" %DEPENDENCYFINDER_CMD_LINE_ARGS%
 goto doneRun
 :noConsole
-start "OO Metrics" "%JAVA_HOME%\bin\javaw" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_HOME%\lib\DependencyFinder.jar;%DEPENDENCYFINDER_HOME%\lib\jakarta-oro.jar;%DEPENDENCYFINDER_HOME%\lib\log4j.jar" com.jeantessier.dependencyfinder.gui.OOMetrics -default-configuration "%DEPENDENCYFINDER_HOME%\etc\MetricsConfig.xml" %DEPENDENCYFINDER_CMD_LINE_ARGS%
+start "OO Metrics" "%JAVA_HOME%\bin\javaw" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_CLASSPATH%" com.jeantessier.dependencyfinder.gui.OOMetrics -default-configuration "%DEPENDENCYFINDER_HOME%\etc\MetricsConfig.xml" %DEPENDENCYFINDER_CMD_LINE_ARGS%
 :doneRun
 
 if not "%OS%"=="Windows_NT" goto mainEnd

--- a/bin/bat.cli.template.txt
+++ b/bin/bat.cli.template.txt
@@ -65,7 +65,12 @@ goto setupArgs
 rem This label provides a place for the argument list loop to break out
 rem and for NT handling to skip to.
 
-"%JAVA_HOME%\bin\java" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_HOME%\lib\DependencyFinder.jar;%DEPENDENCYFINDER_HOME%\lib\jakarta-oro.jar;%DEPENDENCYFINDER_HOME%\lib\log4j.jar;%CLASSPATH%" com.jeantessier.dependencyfinder.cli.##COMMAND## %DEPENDENCYFINDER_CMD_LINE_ARGS%
+set DEPENDENCYFINDER_CLASSPATH=
+
+SETLOCAL ENABLEDELAYEDEXPANSION
+for %%j in (%DEPENDENCYFINDER_HOME%\lib\*.jar) do set DEPENDENCYFINDER_CLASSPATH=!DEPENDENCYFINDER_CLASSPATH!;%%j
+
+"%JAVA_HOME%\bin\java" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_CLASSPATH%;%CLASSPATH%" com.jeantessier.dependencyfinder.cli.##COMMAND## %DEPENDENCYFINDER_CMD_LINE_ARGS%
 
 if not "%OS%"=="Windows_NT" goto mainEnd
 :winNTend

--- a/bin/bat.reporter.template.txt
+++ b/bin/bat.reporter.template.txt
@@ -65,7 +65,12 @@ goto setupArgs
 rem This label provides a place for the argument list loop to break out
 rem and for NT handling to skip to.
 
-"%JAVA_HOME%\bin\java" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_HOME%\lib\DependencyFinder.jar;%DEPENDENCYFINDER_HOME%\lib\jakarta-oro.jar;%DEPENDENCYFINDER_HOME%\lib\log4j.jar" com.jeantessier.dependencyfinder.cli.DependencyReporter -##COMMAND## %DEPENDENCYFINDER_CMD_LINE_ARGS%
+set DEPENDENCYFINDER_CLASSPATH=
+
+SETLOCAL ENABLEDELAYEDEXPANSION
+for %%j in (%DEPENDENCYFINDER_HOME%\lib\*.jar) do set DEPENDENCYFINDER_CLASSPATH=!DEPENDENCYFINDER_CLASSPATH!;%%j
+
+"%JAVA_HOME%\bin\java" %DEPENDENCYFINDER_OPTS% -classpath "%DEPENDENCYFINDER_HOME%\classes;%DEPENDENCYFINDER_CLASSPATH%" com.jeantessier.dependencyfinder.cli.DependencyReporter -##COMMAND## %DEPENDENCYFINDER_CMD_LINE_ARGS%
 
 if not "%OS%"=="Windows_NT" goto mainEnd
 :winNTend


### PR DESCRIPTION
Hey

I tried to use dependency-finder tools (v1.4.0) on Windows and I get errors like this:
```
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/oro/text/perl/Perl5Util
    at com.jeantessier.dependency.NodeFactory.<clinit>(NodeFactory.java:41)
    at com.jeantessier.dependencyfinder.cli.DependencyExtractor.doProcessing(DependencyExtractor.java:68)
    at com.jeantessier.dependencyfinder.cli.Command.process(Command.java:178)
    at com.jeantessier.dependencyfinder.cli.Command.run(Command.java:102)
    at com.jeantessier.dependencyfinder.cli.DependencyExtractor.main(DependencyExtractor.java:101)
Caused by: java.lang.ClassNotFoundException: org.apache.oro.text.perl.Perl5Util
    at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
    at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
    at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
    ... 5 more
```

At the same time, everything works fine on Linux

I changed the bat files a bit so that they added all *.jar files from `%DEPENDENCYFINDER_HOME%\lib\` to the classpath (similar to how it is done in unix scripts) and it helped me, I was able to use the tools with Windows now

so I propose this PR with changes for bat files, maybe it will be useful